### PR TITLE
Adding support for IDS uEye XLS-E

### DIFF
--- a/drivers/src/devices/prophesee_evk4.rs
+++ b/drivers/src/devices/prophesee_evk4.rs
@@ -297,6 +297,11 @@ impl device::Usb for Device {
                     b'U', 0x00, b'E', 0x00, b'-', 0x00, b'3', 0x00, b'9', 0x00, b'B', 0x00, b'0',
                     0x00, b'X', 0x00, b'C', 0x00, b'P', 0x00
                 ],
+                // "UE-39B2XLS" (UTF-16)
+                &[
+                    b'U', 0x00, b'E', 0x00, b'-', 0x00, b'3', 0x00, b'9', 0x00, b'B', 0x00, b'2',
+                    0x00, b'X', 0x00, b'L', 0x00, b'S', 0x00
+                ],
             ],
             TIMEOUT,
         )?;


### PR DESCRIPTION
Added string descriptors for IDS uEye XLS-E to drivers to support camera variant. Ran cargo tests and it passed.